### PR TITLE
Add Feast RAG Retriever Implementation

### DIFF
--- a/rag/README.md
+++ b/rag/README.md
@@ -201,3 +201,63 @@ python examples/research_projects/rag/finetune_rag.py \
     --passages_path path/to/data/my_knowledge_dataset
     --index_path path/to/my_knowledge_dataset_hnsw_index.faiss
 ```
+
+# Feast RAG Retriever
+
+The Feast RAG retriever provides an alternative retrieval backend using [Feast](https://feast.dev/) as a feature store that can integrate with various vector stores (like Milvus, SQLite, DynamoDB, etc.). This allows you to use Feast's scalable feature serving infrastructure for RAG applications.
+
+## Features
+
+- **Multiple Search Types**: Support for text-only, vector-only, and hybrid search
+- **Flexible Vector Store Integration**: Connect to various vector stores through Feast (Milvus, SQLite, DynamoDB, etc.)
+- **Scalable**: Use Feast's distributed architecture for production deployments
+- **Flexible**: Configure custom feature views and search strategies
+
+## Quick Start
+
+1. **Install Dependencies**:
+   ```bash
+   pip install feast
+   ```
+
+2. **Setup Feast Repository**:
+   Create a Feast repository with a feature view containing your documents:
+   ```python
+   from feast import FeatureStore, FeatureView, Field
+   from feast.types import String, Float32
+   
+   # Define your feature view
+   documents_view = FeatureView(
+       name="documents",
+       entities=[],
+       schema=[
+           Field(name="id", dtype=String),
+           Field(name="text", dtype=String),
+           Field(name="title", dtype=String),
+           Field(name="embedding", dtype=Float32, vector_index=True),
+       ],
+       source=your_source,
+   )
+   ```
+
+3. **Use Feast Retriever**:
+   ```python
+   from feast_retriever import FeastRAGRetriever, FeastIndex
+   
+   retriever = FeastRAGRetriever(
+       feast_repo_path="/path/to/feast/repo",
+       feature_view=documents_view,
+       features=["text", "embedding", "title"],
+       search_type="hybrid",
+       id_field="id",
+       text_field="text",
+       question_encoder_tokenizer=question_encoder_tokenizer,
+       question_encoder=question_encoder,
+       generator_tokenizer=generator_tokenizer,
+       generator_model=generator_model,
+       config=config,
+       index=FeastIndex(),
+   )
+   ```
+
+For more information about Feast and its vector store integrations, see the [Feast documentation](https://docs.feast.dev/).

--- a/rag/feast_retriever.py
+++ b/rag/feast_retriever.py
@@ -1,0 +1,339 @@
+from typing import Any, Callable, Optional
+import warnings
+
+import numpy as np
+import torch
+from transformers import (
+    PreTrainedModel,
+    PreTrainedTokenizer,
+    RagRetriever,
+)
+from feast import FeatureStore, FeatureView
+from feast.vector_store import FeastVectorStore
+
+
+class FeastIndex:
+    """Dummy index required by HuggingFace's RagRetriever."""
+
+    def __init__(self):
+        """Initialize the Feast index."""
+        pass
+
+
+class FeastRAGRetriever(RagRetriever):
+    """RAG retriever implementation that uses Feast as a backend."""
+
+    VALID_SEARCH_TYPES = {"text", "vector", "hybrid"}
+
+    def __init__(
+        self,
+        question_encoder_tokenizer: PreTrainedTokenizer,
+        question_encoder: PreTrainedModel,
+        generator_tokenizer: PreTrainedTokenizer,
+        generator_model: PreTrainedModel,
+        feast_repo_path: str,
+        feature_view: FeatureView,
+        features: list[str],
+        search_type: str,
+        config: dict[str, Any],
+        index: FeastIndex,
+        format_document: Optional[Callable[[dict[str, Any]], str]] = None,
+        id_field: str = "",
+        text_field: str = "",
+        **kwargs,
+    ):
+        """Initialize the Feast RAG retriever.
+
+        Args:
+            question_encoder_tokenizer: Tokenizer for encoding questions
+            question_encoder: Model for encoding questions
+            generator_tokenizer: Tokenizer for the generator model
+            generator_model: The generator model
+            feast_repo_path: Path to the Feast repository
+            feature_view: Feast FeatureView containing the document data
+            features: List of feature names to use from the feature view
+            search_type: Type of search to perform (text, vector, or hybrid)
+            config: Configuration for the retriever
+            index: Index instance (must be FeastIndex)
+            format_document: Optional function to format retrieved documents
+            id_field: Field to use as document ID
+            text_field: Field to use as text field name
+            **kwargs: Additional arguments passed to RagRetriever
+        """
+        if search_type.lower() not in self.VALID_SEARCH_TYPES:
+            raise ValueError(
+                f"Unsupported search_type {search_type}. "
+                f"Must be one of: {self.VALID_SEARCH_TYPES}"
+            )
+
+        # move to gpu if available
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.question_encoder = question_encoder.to(self.device)  # type: ignore
+        self.generator_model = generator_model.to(self.device)  # type: ignore
+
+        self.question_encoder_tokenizer = question_encoder_tokenizer
+        self.generator_tokenizer = generator_tokenizer
+
+        super().__init__(
+            config=config,
+            question_encoder_tokenizer=self.question_encoder_tokenizer,
+            generator_tokenizer=self.generator_tokenizer,
+            index=index,
+            init_retrieval=False,
+            **kwargs,
+        )
+
+        self.feast_repo_path = feast_repo_path
+        self.search_type = search_type.lower()
+        self.format_document = format_document or self._default_format_document
+        self.id_field = id_field
+        self.text_field = text_field
+        self.feature_view = feature_view
+        self.features = features
+
+        # Initialize these lazily for compatability with distributed training/tuning
+        self._feature_store = None
+        self._vector_store = None
+
+    @property
+    def feature_store(self):
+        # Initialize FeatureStore lazily
+        if self._feature_store is None:
+            self._feature_store = FeatureStore(repo_path=self.feast_repo_path)
+        return self._feature_store
+
+    @property
+    def vector_store(self):
+        # Initialize FeastVectorStore lazily
+        if self._vector_store is None:
+            self._vector_store = FeastVectorStore(
+                repo_path=self.feast_repo_path,
+                rag_view=self.feature_view,
+                features=self.features,
+            )
+        return self._vector_store
+
+    def retrieve(  # type: ignore [override]
+        self,
+        question_hidden_states: np.ndarray,
+        n_docs: int,
+        query: Optional[str] = None,
+    ) -> tuple[np.ndarray, np.ndarray, list[dict]]:
+        """
+        Overrides the base `retrieve` method to fetch documents from Feast.
+
+        This method processes a batch of questions, queries the vector store,
+        and formats the results into the 3-part tuple expected by the RAG model:
+        (document_embeddings, document_ids, document_dictionaries).
+
+        Args:
+            question_hidden_states (np.ndarray):
+                Hidden state representation of the question from the encoder.
+                Expected shape is (batch_size, seq_len, hidden_dim).
+            n_docs (int):
+                Number of top documents to retrieve.
+            query (Optional[str]):
+                Optional raw query string. If not provided and search_type is "text" or "hybrid",
+                it will be decoded from question_hidden_states.
+
+        Returns:
+            Tuple containing:
+                - retrieved_doc_embeds (np.ndarray):
+                    Embeddings of the retrieved documents with shape (batch_size, n_docs, embed_dim).
+                - doc_ids (np.ndarray):
+                    Array of document IDs or passage identifiers with shape (batch_size, n_docs).
+                - doc_dicts (list[dict[str, str]]):
+                    List of dictionaries containing document text fields.
+        """
+
+        batch_size = question_hidden_states.shape[0]
+
+        # Convert the question hidden states into a list of 1D query vectors.
+        pooled_query_vectors = []
+        for i in range(batch_size):
+            # Average pooling over sequence length to get 1D vector
+            pooled = np.mean(question_hidden_states[i], axis=0)
+            # Perform normalization to create a unit vector.
+            norm = np.linalg.norm(pooled)
+            if norm > 0:
+                pooled = pooled / norm
+            pooled_query_vectors.append(pooled)
+
+        # Determine embedding dimension for padding
+        emb_dim = (
+            pooled_query_vectors[0].shape[-1]
+            if pooled_query_vectors and pooled_query_vectors[0] is not None
+            else self.config.retrieval_vector_size
+        )
+
+        # Retrieve documents for each query in batch
+        batch_embeddings, batch_doc_ids, batch_metadata = [], [], []
+
+        for i in range(batch_size):
+            query_vector = pooled_query_vectors[i]
+            if isinstance(query, list):
+                query_text = query[i] if i < len(query) else None
+            else:
+                query_text = query
+
+            # Query Feast to get the raw document data
+            response = self.vector_store.query(
+                query_vector=query_vector if self.search_type != "text" else None,
+                query_string=query_text if self.search_type != "vector" else None,
+                top_k=n_docs,
+            )
+            results_dict = response.to_dict()
+            # Dynamically get data using the configured feature names
+            texts = results_dict.get(self.text_field, [])
+            ids = results_dict.get(self.id_field, [])
+            num_retrieved = len(texts)
+
+            embeddings = []
+            embedding_field_name = None
+            for field in self.feature_view.schema:
+                if hasattr(field, "vector_index") and field.vector_index:
+                    embedding_field_name = field.name
+                    break
+
+            if embedding_field_name:
+                embeddings = results_dict.get(embedding_field_name, [])
+            else:
+                if self.search_type in ["vector", "hybrid"]:
+                    raise ValueError(
+                        f"No field with 'vector_index=True' found in schema. "
+                        f"Vector search requires embeddings, but only text search is available. "
+                        f"Please either: 1) Add a vector_index field to your schema, or "
+                        f"2) Use search_type='text' instead of '{self.search_type}'"
+                    )
+                else:
+                    warnings.warn(
+                        "No field with 'vector_index=True' found in schema. "
+                        "Using text-only search without embeddings."
+                    )
+                    # For text-only search, we don't need embeddings
+                    embeddings = []
+
+            # Initialize lists for the current query's results
+            current_query_embeddings, current_query_ids, current_query_texts = (
+                [],
+                [],
+                [],
+            )
+
+            # Process retrieved documents up to n_docs
+            emb_array = np.array([])
+            if num_retrieved > 0:
+                if embeddings:  # Only process if we have actual embeddings
+                    try:
+                        emb_array = np.array(
+                            [np.asarray(emb, dtype=np.float32) for emb in embeddings]
+                        )
+                        if emb_array.ndim == 1:  # Reshape if it's a flat array
+                            emb_array = emb_array.reshape(num_retrieved, -1)
+                    except ValueError as e:
+                        warnings.warn(f"Failed to process embeddings: {e}")
+                        emb_array = np.zeros((num_retrieved, emb_dim), dtype=np.float32)
+                else:
+                    # For text-only search, create placeholder embeddings
+                    # These won't be used for similarity but maintain the expected format
+                    emb_array = np.zeros((num_retrieved, emb_dim), dtype=np.float32)
+
+            for k in range(n_docs):
+                if k < num_retrieved:
+                    # Append actual retrieved data
+                    current_query_texts.append(texts[k])
+                    current_query_embeddings.append(emb_array[k])
+                    try:
+                        current_query_ids.append(int(ids[k]))
+                    except (ValueError, TypeError):
+                        current_query_ids.append(-1)  # Use placeholder for invalid IDs
+                else:
+                    # Pad with empty/zero values if fewer than n_docs were found
+                    current_query_texts.append("")
+                    current_query_embeddings.append(np.zeros(emb_dim, dtype=np.float32))
+                    current_query_ids.append(-1)
+
+            # Collate results for the current query
+            batch_embeddings.append(np.array(current_query_embeddings))
+            batch_doc_ids.append(np.array(current_query_ids))
+            batch_metadata.append(
+                {
+                    "text": current_query_texts,
+                    "id": current_query_ids,
+                    "title": [""]
+                    * n_docs,  # RAG model expects a "title" key during Forward pass
+                }
+            )
+
+        # Return the Collated Batch Results
+        # Convert lists of arrays into single batch arrays.
+        return (
+            np.array(batch_embeddings, dtype=np.float32),
+            np.array(batch_doc_ids, dtype=np.int64),
+            batch_metadata,
+        )
+
+    def generate_answer(
+        self, query: str, top_k: int = 5, max_new_tokens: int = 100
+    ) -> str:
+        """A helper method to generate an answer for a single query string.
+
+        Args:
+            query: The query to answer
+            top_k: Number of documents to retrieve
+            max_new_tokens: Maximum number of tokens to generate
+
+        Returns:
+            Generated answer string
+        """
+        if not self.question_encoder or not self.generator_model:
+            raise ValueError(
+                "`question_encoder` and `generator_model` must be provided to use `generate_answer`."
+            )
+
+        # Convert query to hidden states format expected by retrieve
+        inputs = self.question_encoder_tokenizer(
+            query, return_tensors="pt", padding=True, truncation=True
+        ).to(self.question_encoder.device)  # type: ignore
+
+        question_hidden_states = self.question_encoder(**inputs).last_hidden_state
+
+        # Get documents using retrieve method
+        _, _, doc_dicts = self.retrieve(
+            question_hidden_states, n_docs=top_k, query=query
+        )
+
+        contexts = doc_dicts[0]["text"] if doc_dicts else []
+        context_str = "\n\n".join(filter(None, contexts))
+
+        prompt = f"Context: {context_str}\n\nQuestion: {query}\n\nAnswer:"
+
+        generator_inputs = self.generator_tokenizer(prompt, return_tensors="pt").to(
+            self.generator_model.device
+        )  # type: ignore
+        output_ids = self.generator_model.generate(
+            **generator_inputs, max_new_tokens=max_new_tokens
+        )  # type: ignore
+
+        return self.generator_tokenizer.decode(output_ids[0], skip_special_tokens=True)
+
+    def _default_format_document(self, doc: dict[str, Any]) -> str:
+        """Default document formatting function.
+
+        Args:
+            doc: Document dictionary to format
+
+        Returns:
+            Formatted document string
+        """
+        lines = []
+        for key, value in doc.items():
+            # Skip vectors by checking for long float lists
+            if (
+                isinstance(value, list)
+                and len(value) > 10
+                and all(isinstance(x, (float, int)) for x in value)
+            ):
+                continue
+            lines.append(f"{key.replace('_', ' ').capitalize()}: {value}")
+        return "\n".join(lines)

--- a/rag/requirements.txt
+++ b/rag/requirements.txt
@@ -6,3 +6,4 @@ ray >= 1.10.0
 pytorch-lightning >= 1.5.10, <=1.6.0
 transformers
 GitPython
+feast >= 0.34.0


### PR DESCRIPTION
# Add Feast RAG Retriever Implementation

## Overview
This PR adds a new RAG retriever implementation that integrates with [Feast](https://feast.dev/) as a feature store backend, enabling flexible vector store integrations (Milvus, SQLite, DynamoDB, etc.) for RAG applications.

## Changes

### New Files
- **`rag/feast_retriever.py`** - Complete Feast RAG retriever implementation
  - `FeastRAGRetriever` class extending `RagRetriever`
  - Support for text, vector, and hybrid search strategies
  - Integration with Feast's vector store capabilities
  - Proper error handling and graceful fallbacks
  - Lazy initialization for distributed training compatibility

### Modified Files
- **`rag/README.md`** - Added comprehensive Feast retriever documentation
  - Quick start guide with code examples
  - Link to Feast documentation

- **`rag/requirements.txt`** - Added Feast dependency
  - `feast >= 0.34.0`

