### PR TITLE
docs(rag-end2end-retriever): replace broken Google Drive link

### DIFF
--- a/rag-end2end-retriever/README.md
+++ b/rag-end2end-retriever/README.md
@@ -44,7 +44,7 @@ We conducted a simple experiment to investigate the effectiveness of this end2en
 -   Use the question-answer pairs as training data.
 -   Train the system for 10 epochs.
 -   Test the Exact Match (EM) score with the SQuAD dataset's validation set.
--   Training dataset, the knowledge-base, and hyperparameters used in experiments can be accessed from [here](https://drive.google.com/drive/folders/1qyzV-PaEARWvaU_jjpnU_NUS3U_dSjtG?usp=sharing).
+-   Training dataset, the knowledge-base, and hyperparameters used in the original experiments were previously hosted on Google Drive but the link is no longer available (HTTP 404). The hyperparameters can be reconstructed from the `finetune_rag_ray_end2end.sh` script in this directory; the SQuAD passages and question-answer pairs are available from the [official SQuAD release](https://rajpurkar.github.io/SQuAD-explorer/).
 
 # Results
 


### PR DESCRIPTION
The `rag-end2end-retriever/README.md` links to a Google Drive folder for the SQuAD training dataset, knowledge-base, and hyperparameters used in the original experiments. The folder no longer exists - the URL returns HTTP 404 ("Sorry, the file you have requested does not exist") - which blocks anyone trying to reproduce the results.

This was reported in [huggingface/transformers#44868](https://github.com/huggingface/transformers/issues/44868) (filed against the wrong repo, the README lives here).

Verified the link is broken:

```
$ curl -sL -o /dev/null -w "%{http_code}\n" "https://drive.google.com/drive/folders/1qyzV-PaEARWvaU_jjpnU_NUS3U_dSjtG?usp=sharing"
404
```

The fix replaces the dead link with an actionable note pointing readers to:
- The existing `rag-end2end-retriever/finetune_rag_ray_end2end.sh` script in this directory for the hyperparameters.
- The [official SQuAD release](https://rajpurkar.github.io/SQuAD-explorer/) for the dataset.

This keeps reproducibility instructions but removes the misleading URL.

Refs huggingface/transformers#44868.

This contribution was developed with AI assistance (Claude Code).